### PR TITLE
Improve error handling for ReClique SSO

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/config/install/openy_gc_auth.provider.reclique_sso.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/config/install/openy_gc_auth.provider.reclique_sso.yml
@@ -1,5 +1,8 @@
 authorization_server: 'https://[association_slug].recliquecore.com'
 client_id: ''
 client_secret: ''
+error_not_found: 'That user was not found.'
+error_access_denied: 'That user does not have access to Virtual Y.'
+error_invalid: 'Something went wrong.'
 error_accompanying_message: 'Please contact us if you have any questions.'
 login_mode: 'present_login_button'

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Controller/SSOController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Controller/SSOController.php
@@ -113,7 +113,7 @@ class SSOController extends ControllerBase {
       return new RedirectResponse(
         URL::fromUserInput(
           $this->configOpenyGatedContent->get('virtual_y_login_url'),
-          ['query' => ['error' => '1']]
+          ['query' => ['error' => 'invalid']]
         )->toString()
       );
     }
@@ -124,7 +124,7 @@ class SSOController extends ControllerBase {
       return new RedirectResponse(
         URL::fromUserInput(
           $this->configOpenyGatedContent->get('virtual_y_login_url'),
-          ['query' => ['error' => '1']]
+          ['query' => ['error' => 'invalid']]
         )->toString()
       );
     }
@@ -135,7 +135,7 @@ class SSOController extends ControllerBase {
       return new RedirectResponse(
         URL::fromUserInput(
           $this->configOpenyGatedContent->get('virtual_y_login_url'),
-          ['query' => ['error' => '1']]
+          ['query' => ['error' => 'not_found']]
         )->toString()
       );
     }
@@ -149,8 +149,16 @@ class SSOController extends ControllerBase {
 
       return new RedirectResponse($this->configOpenyGatedContent->get('virtual_y_url'));
     }
+    if ($this->recliqueSSOClient->validateUserSubscription($userData) === FALSE) {
+      return new RedirectResponse(
+        URL::fromUserInput(
+          $this->configOpenyGatedContent->get('virtual_y_login_url'),
+          ['query' => ['error' => 'access_denied']]
+        )->toString()
+      );
+    }
 
-    // Redirect back to Virual Y login page.
+    // Redirect back to Virtual Y login page.
     return new RedirectResponse(
       URL::fromUserInput(
         $this->configOpenyGatedContent->get('virtual_y_login_url'),

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Form/TryAgainForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Form/TryAgainForm.php
@@ -63,10 +63,14 @@ class TryAgainForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    if (!empty($this->currentRequest->query->get('error'))) {
-      $form['error'] = [
-        '#markup' => '<h4 class="alert alert-danger text-center">' . $this->t('There may be a problem with your account') . '</h4>',
-      ];
+    $error = $this->currentRequest->query->get('error');
+    if (!empty($error)) {
+      if ($message = $this->configFactory->get('openy_gc_auth.provider.reclique_sso')
+        ->get("error_{$error}")) {
+        $form['error'] = [
+          '#markup' => '<h4 class="alert alert-danger text-center">' . $message . '</h4>',
+        ];
+      }
 
       $form['error_contact_message'] = [
         '#markup' => '<div class="alert alert-info text-center">' . $this->configFactory->get('openy_gc_auth.provider.reclique_sso')

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Plugin/GCIdentityProvider/RecliqueSSO.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Plugin/GCIdentityProvider/RecliqueSSO.php
@@ -95,6 +95,9 @@ class RecliqueSSO extends GCIdentityProviderPluginBase {
     return [
       'authorization_server' => 'https://[association_slug].recliquecore.com',
       'login_mode' => 'present_login_button',
+      'error_not_found' => 'That user was not found.',
+      'error_access_denied' => 'That user does not have access to Virtual Y.',
+      'error_invalid' => 'Something went wrong.'
     ];
   }
 
@@ -109,26 +112,50 @@ class RecliqueSSO extends GCIdentityProviderPluginBase {
       '#type' => 'url',
       '#title' => $this->t('Authorization server'),
       '#default_value' => $config['authorization_server'],
-      '#description' => $this->t('It is most likely "https://[association_slug].recliquecore.com", where association_slug should be provided from Reclique.'),
+      '#description' => $this->t('It is most likely "https://[association_slug].recliquecore.com", where association_slug should be provided from ReClique.'),
     ];
 
     $form['client_id'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Client Id'),
       '#default_value' => $config['client_id'],
-      '#description' => $this->t('Your Reclique client id.'),
+      '#description' => $this->t('Your ReClique client id.'),
     ];
 
     $form['client_secret'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Client Secret'),
       '#default_value' => $config['client_secret'],
-      '#description' => $this->t('Your Reclique client secret.'),
+      '#description' => $this->t('Your ReClique client secret.'),
+    ];
+
+    $form['error_not_found'] = [
+      '#title' => $this->t('Message for "not found" errors.'),
+      '#description' => $this->t('Message displayed when the user is not found in ReClique.'),
+      '#type' => 'textfield',
+      '#default_value' => $config['error_not_found'],
+      '#required' => FALSE,
+    ];
+
+    $form['error_access_denied'] = [
+      '#title' => $this->t('Message for "access denied" errors.'),
+      '#description' => $this->t('Message displayed when the user does not have privileges to Virtual Y.'),
+      '#type' => 'textfield',
+      '#default_value' => $config['error_access_denied'],
+      '#required' => FALSE,
+    ];
+
+    $form['error_invalid'] = [
+      '#title' => $this->t('Message for all other errors.'),
+      '#description' => $this->t('Message displayed for any other errors communicating with ReClique.'),
+      '#type' => 'textfield',
+      '#default_value' => $config['error_invalid'],
+      '#required' => FALSE,
     ];
 
     $form['error_accompanying_message'] = [
       '#title' => $this->t('Authentication error message'),
-      '#description' => $this->t('Message displayed to user when he failed to log in using this plugin.'),
+      '#description' => $this->t('Additional help displayed after all login failures.'),
       '#type' => 'textfield',
       '#default_value' => $config['error_accompanying_message'],
       '#required' => FALSE,
@@ -157,6 +184,9 @@ class RecliqueSSO extends GCIdentityProviderPluginBase {
       $this->configuration['authorization_server'] = $form_state->getValue('authorization_server');
       $this->configuration['client_id'] = $form_state->getValue('client_id');
       $this->configuration['client_secret'] = $form_state->getValue('client_secret');
+      $this->configuration['error_not_found'] = $form_state->getValue('error_not_found');
+      $this->configuration['error_access_denied'] = $form_state->getValue('error_access_denied');
+      $this->configuration['error_invalid'] = $form_state->getValue('error_invalid');
       $this->configuration['error_accompanying_message'] = $form_state->getValue('error_accompanying_message');
       $this->configuration['login_mode'] = $form_state->getValue('login_mode');
 


### PR DESCRIPTION


**Related Issue/Ticket:** YMCA Dallas client work - improving error handling on ReClique SSO. ReClique doesn't have specific error messages but I took guidance from https://github.com/YCloudYUSA/yusaopeny_gated_content/blob/15dd85f4f93b61f3235a78951176f42fb0e0bbbc/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/config/install/openy_gc_auth.provider.daxko_barcode.yml#L5-L9

## Steps to test:

- [ ] Configure VY to use the ReClique SSO Auth provider
- [ ] Attempt to log in with a user account without privileges, a user account with privileges, and other states.
- [ ] Observe the error messages are better than they were before. 
- [ ] observe messages are configurable on /admin/openy/virtual-ymca/gc-auth-settings/provider/reclique_sso

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
