### PR TITLE
feat: Add autologin option to Dummy provider

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_example/js/openy_gc_auth_example.js
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_example/js/openy_gc_auth_example.js
@@ -1,0 +1,13 @@
+/**
+ * @file
+ * JavaScript for openy_gc_auth_example.
+ */
+(function ($, Drupal) {
+
+  Drupal.behaviors.openy_gc_auth_example = {
+    attach: function(context, settings) {
+      $('input[data-autosubmit=1]', context).once('openy_gc_auth_example').form().submit();
+    }
+  };
+
+})(jQuery, Drupal);

--- a/modules/openy_gc_auth/modules/openy_gc_auth_example/openy_gc_auth_example.libraries.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_example/openy_gc_auth_example.libraries.yml
@@ -1,0 +1,5 @@
+openy_gc_auth_example:
+  js:
+    js/openy_gc_auth_example.js: {}
+  dependencies:
+    - core/jquery

--- a/modules/openy_gc_auth/modules/openy_gc_auth_example/openy_gc_auth_example.libraries.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_example/openy_gc_auth_example.libraries.yml
@@ -1,5 +1,6 @@
 openy_gc_auth_example:
+  version: 1.0
   js:
-    js/openy_gc_auth_example.js: {}
+    js/openy_gc_auth_example.js: { minified: false }
   dependencies:
     - core/jquery

--- a/modules/openy_gc_auth/modules/openy_gc_auth_example/src/Form/VirtualYExampleLoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_example/src/Form/VirtualYExampleLoginForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\openy_gc_auth_example\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\openy_gc_auth\GCUserAuthorizer;
@@ -30,14 +31,23 @@ class VirtualYExampleLoginForm extends FormBase {
   protected $gcUserAuthorizer;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * {@inheritdoc}
    */
   public function __construct(
     RequestStack $requestStack,
-    GCUserAuthorizer $gcUserAuthorizer
+    GCUserAuthorizer $gcUserAuthorizer,
+    ConfigFactoryInterface $config_factory
   ) {
     $this->currentRequest = $requestStack->getCurrentRequest();
     $this->gcUserAuthorizer = $gcUserAuthorizer;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -46,7 +56,8 @@ class VirtualYExampleLoginForm extends FormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('request_stack'),
-      $container->get('openy_gc_auth.user_authorizer')
+      $container->get('openy_gc_auth.user_authorizer'),
+      $container->get('config.factory')
     );
   }
 
@@ -61,10 +72,20 @@ class VirtualYExampleLoginForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $provider_config = $this->configFactory->get('openy_gc_auth.provider.dummy');
+    $autosubmit = $provider_config->get('autosubmit');
 
     $form['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Enter Virtual Y'),
+      '#attached' => [
+        'library' => [
+          'openy_gc_auth_example/openy_gc_auth_example'
+        ]
+      ],
+      '#attributes' => [
+        'data-autosubmit' => $autosubmit,
+      ]
     ];
 
     return $form;

--- a/modules/openy_gc_auth/modules/openy_gc_auth_example/src/Plugin/GCIdentityProvider/Example.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_example/src/Plugin/GCIdentityProvider/Example.php
@@ -25,6 +25,7 @@ class Example extends GCIdentityProviderPluginBase {
       'token' => '',
       'password' => '',
       'redirect_url' => '',
+      'autosubmit' => ''
     ];
   }
 
@@ -67,6 +68,13 @@ class Example extends GCIdentityProviderPluginBase {
       '#required' => TRUE,
     ];
 
+    $form['autosubmit'] = [
+      '#title' => $this->t('Autosubmit'),
+      '#description' => $this->t('Automatically submit the login form'),
+      '#type' => 'checkbox',
+      '#default_value' => $config['autosubmit'] ?? FALSE,
+    ];
+
     return $form;
   }
 
@@ -78,6 +86,7 @@ class Example extends GCIdentityProviderPluginBase {
       $this->configuration['user'] = $form_state->getValue('user');
       $this->configuration['token'] = $form_state->getValue('token');
       $this->configuration['redirect_url'] = $form_state->getValue('redirect_url');
+      $this->configuration['autosubmit'] = $form_state->getValue('autosubmit');
       if ($form_state->getValue('password')) {
         // Override only in case empty value.
         $this->configuration['password'] = $form_state->getValue('password');


### PR DESCRIPTION
**Related Issue/Ticket:**

Add option for dummy provider to "auto-login", providing a kind of "demo mode" for VY

## Steps to test:

- [ ] Observe new option on Dummy provider.
- [ ] observe when "autosubmit" is chosen the user is directed directly to VY instead of getting the "Log in to VY" button.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
