### PR TITLE
feat: Add permissions mapping to reclique_sso

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/config/install/openy_gc_auth.provider.reclique_sso.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/config/install/openy_gc_auth.provider.reclique_sso.yml
@@ -1,5 +1,11 @@
 authorization_server: 'https://[association_slug].recliquecore.com'
 client_id: ''
 client_secret: ''
+error_access_denied: 'That user does not have access to Virtual Y.'
 error_accompanying_message: 'Please contact us if you have any questions.'
+error_invalid: 'Something went wrong.'
+error_not_found: 'That user was not found.'
 login_mode: 'present_login_button'
+membership_field: 'PackageName'
+permissions_mapping: ''
+require_active: 1

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/openy_gc_auth_reclique_sso.services.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/openy_gc_auth_reclique_sso.services.yml
@@ -1,4 +1,9 @@
 services:
+  openy_gc_auth.reclique_sso_user_login_subscriber:
+    class: '\Drupal\openy_gc_auth_reclique_sso\EventSubscriber\GCAuthReCliqueSSOUserLoginSubscriber'
+    arguments: [ '@config.factory' ]
+    tags:
+      - { name: 'event_subscriber' }
   openy_gc_auth.reclique_sso_client:
     class: Drupal\openy_gc_auth_reclique_sso\SSOClient
     arguments: ['@logger.factory', '@config.factory', '@http_client', '@csrf_token', '@tempstore.private' ]

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Controller/SSOController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Controller/SSOController.php
@@ -145,7 +145,7 @@ class SSOController extends ControllerBase {
         ->prepareUserNameAndEmail($userData);
 
       // Authorize user (register, login, log, etc).
-      $this->gcUserAuthorizer->authorizeUser($name, $email);
+      $this->gcUserAuthorizer->authorizeUser($name, $email, (array) $userData);
 
       return new RedirectResponse($this->configOpenyGatedContent->get('virtual_y_url'));
     }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/EventSubscriber/GCAuthReCliqueSSOUserLoginSubscriber.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/EventSubscriber/GCAuthReCliqueSSOUserLoginSubscriber.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\openy_gc_auth_reclique_sso\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Url;
+use Drupal\openy_gc_auth\Event\GCUserLoginEvent;
+use Drupal\user\Entity\User;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Class GCAuthReCliqueSSOUserLoginSubscriber provides ReClique SSO login Subscriber.
+ *
+ * @package Drupal\openy_gc_auth_reclique_sso\EventSubscriber
+ */
+class GCAuthReCliqueSSOUserLoginSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Config for openy_gc_auth_reclique_sso module.
+   *
+   * @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
+   */
+  protected $configRecliqueSSO;
+
+  /**
+   * Constructs a new GCAuthReCliqueSSOUserLoginSubscriber.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   Config factory.
+   */
+  public function __construct(ConfigFactoryInterface $configFactory) {
+    $this->configFactory = $configFactory;
+    $this->configRecliqueSSO = $configFactory->get('openy_gc_auth.provider.reclique_sso');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      // Static class constant => method on this class.
+      GCUserLoginEvent::EVENT_NAME => 'onUserLogin',
+    ];
+  }
+
+  /**
+   * Subscribe to the GC user login event dispatched.
+   *
+   * @param \Drupal\openy_gc_auth\Event\GCUserLoginEvent $event
+   *   Event object.
+   */
+  public function onUserLogin(GCUserLoginEvent $event) {
+
+    if ($this->configFactory->get('openy_gc_auth.settings')->get('active_provider') == 'reclique_sso') {
+      $permissions_mapping = $this->configRecliqueSSO->get('permissions_mapping');
+      $require_active = $this->configRecliqueSSO->get('require_active');
+
+      if ($event->account instanceof User && !empty($event->extraData)) {
+        $account = $event->account;
+        if (isset($event->extraData['member'])) {
+          $account_roles = $account->getRoles();
+          // Remove all virtual_y roles (in case if any changes in membership).
+          foreach ($account_roles as $account_role) {
+            if (strstr($account_role, 'virtual_y')) {
+              $account->removeRole($account_role);
+            }
+          }
+          $membership_field = $this->configRecliqueSSO->get('membership_field');
+          $user_membership = $event->extraData['member']->{$membership_field};
+          $active_roles = [];
+          $permissions_mapping = explode(';', $permissions_mapping);
+          foreach ($permissions_mapping as $mapping) {
+            $role = explode(':', $mapping);
+            // Compare mapping roles with user membership.
+            if (isset($role[0]) && $role[0] == $user_membership && isset($role[1])) {
+              $active_roles[] = $role[1];
+            }
+          }
+          if ($require_active && $user_membership && empty($active_roles)) {
+            $active_roles = ['virtual_y'];
+          }
+          foreach ($active_roles as $role) {
+            $account->addRole($role);
+          }
+          $account->save();
+        }
+      }
+    }
+  }
+
+}

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/EventSubscriber/GCAuthReCliqueSSOUserLoginSubscriber.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/EventSubscriber/GCAuthReCliqueSSOUserLoginSubscriber.php
@@ -80,8 +80,12 @@ class GCAuthReCliqueSSOUserLoginSubscriber implements EventSubscriberInterface {
           foreach ($permissions_mapping as $mapping) {
             $role = explode(':', $mapping);
             // Compare mapping roles with user membership.
-            if (isset($role[0]) && $role[0] == $user_membership && isset($role[1])) {
-              $active_roles[] = $role[1];
+            if (!empty($role[0]) && !empty($role[1])) {
+              $role_pattern = '/^(' . preg_replace('/[^\\\\](\*)/', '.*', $role[0]) . ')$/';
+              // If we hit a match add that to the active roles.
+              if (preg_match($role_pattern, $user_membership)) {
+                $active_roles[] = $role[1];
+              }
             }
           }
           if ($require_active && $user_membership && empty($active_roles)) {

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Plugin/GCIdentityProvider/RecliqueSSO.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/Plugin/GCIdentityProvider/RecliqueSSO.php
@@ -3,6 +3,7 @@
 namespace Drupal\openy_gc_auth_reclique_sso\Plugin\GCIdentityProvider;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -25,6 +26,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class RecliqueSSO extends GCIdentityProviderPluginBase {
 
+  use DependencySerializationTrait;
   use MessengerTrait;
 
   /**
@@ -94,7 +96,16 @@ class RecliqueSSO extends GCIdentityProviderPluginBase {
   public function defaultConfiguration(): array {
     return [
       'authorization_server' => 'https://[association_slug].recliquecore.com',
+      'client_id' => '',
+      'client_secret' => '',
+      'error_access_denied' => 'That user does not have access to Virtual Y.',
+      'error_accompanying_message' => 'Please contact us if you have any questions.',
+      'error_invalid' => 'Something went wrong.',
+      'error_not_found' => 'That user was not found.',
       'login_mode' => 'present_login_button',
+      'membership_field' => 'PackageName',
+      'permissions_mapping' => '',
+      'require_active' => 1
     ];
   }
 
@@ -104,6 +115,75 @@ class RecliqueSSO extends GCIdentityProviderPluginBase {
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $config = $this->getConfiguration();
     $form = parent::buildConfigurationForm($form, $form_state);
+    $form['#tree'] = TRUE;
+
+    $form['permissions_mapping'] = [
+      '#title' => $this->t('Permissions mapping'),
+      '#type' => 'details',
+      '#open' => TRUE,
+      '#prefix' => '<div id="permissions-mapping-fieldset-wrapper">',
+      '#suffix' => '</div>',
+    ];
+
+    $form['permissions_mapping']['require_active'] = [
+      '#title' => $this->t('Require "Active" status'),
+      '#description' => $this->t("Set to TRUE if users are required to have an Active status.<br/>
+        If TRUE, all Active users will receive <em>at least</em> basic Virtual Y access.<br/>
+        If FALSE no users will have access unless their membership matches a mapping below."),
+      '#type' => 'checkbox',
+      '#default_value' => $config['require_active'],
+    ];
+
+    $form['permissions_mapping']['membership_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Membership field'),
+      '#default_value' => $config['membership_field'],
+      '#description' => $this->t('The field in the ReClique "member" object to check for the values below.'),
+    ];
+
+    $permissions_mapping = explode(';', $config['permissions_mapping']);
+    if (!$form_state->has('permissions_mapping_items_count')) {
+      $form_state->set('permissions_mapping_items_count', count($permissions_mapping));
+    }
+    $permissions_mapping_items = $form_state->get('permissions_mapping_items_count');
+    $roles = $this->gcUserService->getRoles();
+    for ($i = 0; $i < $permissions_mapping_items; $i++) {
+      $role = isset($permissions_mapping[$i]) ? explode(':', $permissions_mapping[$i]) : '';
+      $form['permissions_mapping'][$i]['permissions_mapping_reclique_role'] = [
+        '#title' => $this->t('ReClique membership'),
+        '#type' => 'textfield',
+        '#default_value' => isset($role[0]) ? $role[0] : '',
+        '#size' => 30,
+        '#prefix' => '<div class="container-inline">',
+      ];
+
+      $form['permissions_mapping'][$i]['permissions_mapping_role'] = [
+        '#title' => $this->t('Virtual Y role'),
+        '#type' => 'select',
+        '#options' => ['' => $this->t('None')] + $roles,
+        '#default_value' => isset($role[1]) ? $role[1] : '',
+        '#suffix' => '</div>',
+      ];
+    }
+
+    $form['permissions_mapping']['description'] = [
+      '#markup' => $this->t("Set member roles to map to Virtual Y roles. <br/>
+        Use <code>*</code> as a wildcard, use <code>\*</code> to search for <code>*</code> itself."),
+    ];
+
+    $form['permissions_mapping']['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['permissions_mapping']['actions']['add'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add one more'),
+      '#submit' => [[get_class($this), 'addOne']],
+      '#ajax' => [
+        'callback' => [get_class($this), 'addmoreCallback'],
+        'wrapper' => 'permissions-mapping-fieldset-wrapper',
+      ],
+    ];
 
     $form['authorization_server'] = [
       '#type' => 'url',
@@ -150,16 +230,56 @@ class RecliqueSSO extends GCIdentityProviderPluginBase {
   }
 
   /**
+   * Add more item.
+   *
+   * @param array $form
+   *   Form data.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   */
+  public static function addOne(array &$form, FormStateInterface $form_state) {
+    $permissions_mapping_items = $form_state->get('permissions_mapping_items_count');
+    $add_button = $permissions_mapping_items + 1;
+    $form_state->set('permissions_mapping_items_count', $add_button);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Add more callback.
+   *
+   * @param array $form
+   *   Form data.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   *
+   * @return mixed
+   *   Return array with data.
+   */
+  public static function addmoreCallback(array &$form, FormStateInterface $form_state) {
+    return $form['settings']['permissions_mapping'];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     if (!$form_state->getErrors()) {
-      $this->configuration['authorization_server'] = $form_state->getValue('authorization_server');
-      $this->configuration['client_id'] = $form_state->getValue('client_id');
-      $this->configuration['client_secret'] = $form_state->getValue('client_secret');
-      $this->configuration['error_accompanying_message'] = $form_state->getValue('error_accompanying_message');
-      $this->configuration['login_mode'] = $form_state->getValue('login_mode');
-
+      $this->configuration['authorization_server'] = $form_state->getValue('settings')['authorization_server'];
+      $this->configuration['client_id'] = $form_state->getValue('settings')['client_id'];
+      $this->configuration['client_secret'] = $form_state->getValue('settings')['client_secret'];
+      $this->configuration['error_not_found'] = $form_state->getValue('settings')['error_not_found'];
+      $this->configuration['error_access_denied'] = $form_state->getValue('settings')['error_access_denied'];
+      $this->configuration['error_invalid'] = $form_state->getValue('settings')['error_invalid'];
+      $this->configuration['error_accompanying_message'] = $form_state->getValue('settings')['error_accompanying_message'];
+      $this->configuration['login_mode'] = $form_state->getValue('settings')['login_mode'];
+      foreach ($form_state->getValue('settings')['permissions_mapping'] as $mapping) {
+        if (!empty($mapping['permissions_mapping_reclique_role'])) {
+          $permissions_mapping[] = $mapping['permissions_mapping_reclique_role'] . ':' . $mapping['permissions_mapping_role'];
+        }
+      }
+      $this->configuration['permissions_mapping'] = !empty($permissions_mapping) ? implode(';', $permissions_mapping) : '';
+      $this->configuration['require_active'] = $form_state->getValue('settings')['permissions_mapping']['require_active'];
+      $this->configuration['membership_field'] = $form_state->getValue('settings')['permissions_mapping']['membership_field'];
       parent::submitConfigurationForm($form, $form_state);
     }
   }


### PR DESCRIPTION
Adds permissions mapping to gc_auth_reclique_sso. This change attempts to keep the existing behavior the same but add a number of options to increase flexibility for different ReClique setups. It also cleans up some changes from #2.

The ReClique SSO configuration now has a number of additional fields, all of which default to their prior behavior but provide options for flexible permissions mapping.

![Identity_Provider___YMCA_of_Metropolitan_Dallas](https://user-images.githubusercontent.com/238201/181356139-a7376bfd-12dd-46a8-8284-b28a3485d938.png)


## Steps to test:

- [ ] Enable openy_gc_auth_reclique_sso
- [ ] Configure it, observe the settings form saves correctly.
- [ ] Ensure folks can log in and receive the proper roles.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
