### PR TITLE
bug: Update icon path from profile to module

### DIFF
--- a/assets/css/admin_ui_styles.css
+++ b/assets/css/admin_ui_styles.css
@@ -1,5 +1,5 @@
 .toolbar-icon-openy-gated-content-openy:before {
-  background-image: url(/profiles/contrib/openy/modules/custom/openy_system/assets/images/icon-gear-inactive.png);
+  background-image: url(/modules/contrib/openy_custom/openy_system/assets/images/icon-gear-inactive.png);
 }
 
 #edit-app-settings-components .draggable a.tabledrag-handle {


### PR DESCRIPTION
Tiny fix to icon path. Will probably need to be fixed again if things move.

## Steps to test:

- [ ] First do this
- [ ] Then do this (and look at this great screenshot).
- [ ] Finally observe the issue is resolved.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
