### PR TITLE
Add on|off toggle for log_archiver cron job in config 

### DIFF
--- a/modules/openy_gc_log/config/install/openy_gc_log.settings.yml
+++ b/modules/openy_gc_log/config/install/openy_gc_log.settings.yml
@@ -1,1 +1,3 @@
 activity_granularity_interval: 600
+archiver_enabled: true
+archiver_store_period: '1 month'

--- a/modules/openy_gc_log/config/install/openy_gc_log.settings.yml
+++ b/modules/openy_gc_log/config/install/openy_gc_log.settings.yml
@@ -1,3 +1,3 @@
 activity_granularity_interval: 600
 archiver_enabled: true
-archiver_store_period: '1 month'
+archiver_store_period: '1 year'

--- a/modules/openy_gc_log/openy_gc_log.module
+++ b/modules/openy_gc_log/openy_gc_log.module
@@ -36,9 +36,12 @@ function openy_gc_log_preprocess_views_view(array &$variables) {
  * Implements hook_cron().
  */
 function openy_gc_log_cron() {
-  $archiver = \Drupal::service("openy_gc_log.log_archiver");
-  $archiver->setWorkerChunkSize(600);
-  $archiver->archive();
+  $enabled = \Drupal::config('openy_gc_log.settings')->get('archiver_enabled');
+  if ($enabled) {
+    $archiver = \Drupal::service("openy_gc_log.log_archiver");
+    $archiver->setWorkerChunkSize(600);
+    $archiver->archive();
+  }
 }
 
 /**

--- a/modules/openy_gc_log/src/Form/LogSettingsForm.php
+++ b/modules/openy_gc_log/src/Form/LogSettingsForm.php
@@ -52,30 +52,6 @@ class LogSettingsForm extends ConfigFormBase {
         3600 => $this->t('1 hour'),
       ],
     ];
-    $form['app_settings']['archiver_enabled'] = [
-      '#title' => $this->t('Enable Log Archiver'),
-      '#type' => 'checkbox',
-      '#default_value' => $config->get('archiver_enabled'),
-    ];
-
-    $form['app_settings']['archiver_store_period'] = [
-      '#title' => $this->t('Default archiver store period of time (months)'),
-      '#type' => 'select',
-      '#options' => [
-        '' => $this->t('1 month'),
-        '2 months' => $this->t('2 months'),
-        '3 months' => $this->t('3 months'),
-        '6 months' => $this->t('6 months'),
-        '9 months' => $this->t('9 months'),
-        '12 months' => $this->t('12 months'),
-      ],
-      '#default_value' => $config->get('archiver_store_period'),
-      '#states' => [
-        'visible' => [
-          ':input[name="app_settings[archiver_enabled]"]' => ['checked' => true]
-        ]
-      ]
-    ];
 
     $form['actions']['#type'] = 'actions';
     $form['actions']['submit'] = [

--- a/modules/openy_gc_log/src/Form/LogSettingsForm.php
+++ b/modules/openy_gc_log/src/Form/LogSettingsForm.php
@@ -52,6 +52,30 @@ class LogSettingsForm extends ConfigFormBase {
         3600 => $this->t('1 hour'),
       ],
     ];
+    $form['app_settings']['archiver_enabled'] = [
+      '#title' => $this->t('Enable Log Archiver'),
+      '#type' => 'checkbox',
+      '#default_value' => $config->get('archiver_enabled'),
+    ];
+
+    $form['app_settings']['archiver_store_period'] = [
+      '#title' => $this->t('Default archiver store period of time (months)'),
+      '#type' => 'select',
+      '#options' => [
+        '' => $this->t('1 month'),
+        '2 months' => $this->t('2 months'),
+        '3 months' => $this->t('3 months'),
+        '6 months' => $this->t('6 months'),
+        '9 months' => $this->t('9 months'),
+        '12 months' => $this->t('12 months'),
+      ],
+      '#default_value' => $config->get('archiver_store_period'),
+      '#states' => [
+        'visible' => [
+          ':input[name="app_settings[archiver_enabled]"]' => ['checked' => true]
+        ]
+      ]
+    ];
 
     $form['actions']['#type'] = 'actions';
     $form['actions']['submit'] = [

--- a/modules/openy_gc_log/src/LogArchiver.php
+++ b/modules/openy_gc_log/src/LogArchiver.php
@@ -195,7 +195,12 @@ class LogArchiver {
     $end_time = $end->getTimeStamp();
 
     if (!isset($start)) {
+      $archiver_period = $this->config->get('openy_gc_log.settings')->get('archiver_store_period') ?? '1 month';
       $start = clone $end;
+      if ($archiver_period !== '') {
+        $start->modify('-' . $archiver_period);
+      }
+
       $start->modify('first day of this month 00:00');
     }
     else {


### PR DESCRIPTION
**YUOPENY-8**

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

https://fivejars.atlassian.net/browse/YUOPENY-8

## Steps to test:

- [ ] Change config file `openy_gc_log.settings`, set value for `archiver_enabled` as `false`
- [ ] Verify that log archiver does not create files on cron executions.
- [ ] Change config `openy_gc_log.settings`, set value for `archiver_enabled` as `true` and set `archiver_store_period` value as `3 months`
- [ ] Verify that log archiver creates files for period of 3 last months. N.B.:There should be enough logs for test

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
