### PR TITLE
[Lily theme]Remove empty space between the menu and the date bar [YUOPENY-19]

### DIFF
--- a/assets/css/openy_lily.css
+++ b/assets/css/openy_lily.css
@@ -41,9 +41,6 @@
 .openy_lily-based.openy-gated-content.toolbar-fixed #gated-content .calendar .desktop .slot.dates {
   top: 370px !important;
 }
-.openy_lily-based.openy-gated-content .layout-content #gated-content .gated-content-schedule-page {
-  padding-top: 86px !important;
-}
 .openy_lily-based.openy-gated-content.alerts #gated-content .gated-content-schedule-page,
 .openy_lily-based.openy-gated-content.alerts #gated-content .gated-content-favorites-page,
 .openy_lily-based.openy-gated-content.alerts #gated-content .gated-content-categories-page,
@@ -99,5 +96,8 @@
   }
   .openy_lily-based.openy-gated-content.toolbar-fixed .page-head.tiny .primary_menu {
     margin-top: 54px;
+  }
+  .openy_lily-based.openy-gated-content .layout-content #gated-content .gated-content-schedule-page {
+    padding-top: 86px !important;
   }
 }


### PR DESCRIPTION
**Related Issue/Ticket:** YUOPENY-19

[https://fivejars.atlassian.net/browse/YUOPENY-19](https://fivejars.atlassian.net/browse/YUOPENY-19)

## Steps to test:

- [ ] Visit Virtual Y Schedule frontend (`/virtual-ymca#/schedule`) via Mobile device or emulator
- [ ] There should be no empty space between header and calendar navigation

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [x ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
