### PR TITLE
[Shared Content] Preview doesn't work [DS-47]

### DIFF
--- a/modules/openy_gc_shared_content/src/Controller/PreviewController.php
+++ b/modules/openy_gc_shared_content/src/Controller/PreviewController.php
@@ -71,7 +71,7 @@ class PreviewController extends ControllerBase {
       $this->currentUser()->id(),
       $shared_content_source_server->id() . '_previewed'
     );
-    if (!in_array($uuid, $previewed)) {
+    if (is_array($previewed) && !in_array($uuid, $previewed)) {
       $previewed[] = $uuid;
     }
     $this->userData->set('openy_gc_shared_content',


### PR DESCRIPTION
**[Shared Content] Preview doesn't work**

[(DS-47)](https://yusa.atlassian.net/browse/DS-47)

## Steps to test:

- [ ] As admin make sure Shared content modules are installed on e.g. Rose and Carnation themes
- [ ] go to admin/virtual-y/shared-content/server on Carnation
- [ ] add Rose environment as new source
- [ ] make sure the token was generated 
- [ ] go to /admin/virtual-y/shared-content/shared_content_source on the Rose theme and check the Status checkbox
- [ ] go to admin/virtual-y/shared-content/server on the Carnation theme and click the Fetch button
- [ ] click the Preview button
- [ ] you should see Popup with preview of the 


## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
