### PR TITLE
[DS-275] Add a separate submit's handler to update the Daxko Whitelist URL

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_daxko_sso/src/Plugin/GCIdentityProvider/DaxkoSSO.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_daxko_sso/src/Plugin/GCIdentityProvider/DaxkoSSO.php
@@ -57,6 +57,7 @@ class DaxkoSSO extends GCIdentityProviderPluginBase {
     return [
       'redirect_url' => '',
       'login_mode' => 'present_login_button',
+      'update_daxko_url_whitelist' => FALSE,
     ];
   }
 
@@ -141,6 +142,32 @@ class DaxkoSSO extends GCIdentityProviderPluginBase {
       '#description' => $this->t('Record each user login as a Virtual Branch Check In.'),
     ];
 
+    $baseUrl = $this->request->getSchemeAndHttpHost();
+
+    $form['update_daxko_url_whitelist'] = [
+      '#title' => $this->t('Update Daxko URL whitelist.'),
+      '#type' => 'checkbox',
+      '#default_value' => $config['update_daxko_url_whitelist'],
+      '#description' => $this->t('After confirming this update the redirect URL on the Daxko API side will change to <b>@url.</b>',
+        [
+          '@url' => $baseUrl . $config['redirect_url']
+        ]),
+    ];
+
+    $form['actions']['submit']['submit_update_daxko_url_whitelist'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Confirm Update'),
+      '#states' => [
+        'visible' => [
+          ':input[name="update_daxko_url_whitelist"]' => ['checked' => TRUE],
+        ],
+      ],
+      '#attributes' => [
+        'class' => ['form-item'],
+      ],
+      '#submit' => [[$this, 'updateDaxkoWhiteListUrlSubmit']],
+    ];
+
     return $form;
   }
 
@@ -153,6 +180,15 @@ class DaxkoSSO extends GCIdentityProviderPluginBase {
       $this->configuration['error_accompanying_message'] = $form_state->getValue('error_accompanying_message');
       $this->configuration['login_mode'] = $form_state->getValue('login_mode');
       $this->configuration['virtual_branch_check_in'] = $form_state->getValue('virtual_branch_check_in');
+      parent::submitConfigurationForm($form, $form_state);
+    }
+  }
+
+  /**
+   * Custom submit handler to update Daxko White List URI.
+   */
+  public function updateDaxkoWhiteListUrlSubmit(array &$form, FormStateInterface $form_state) {
+    if (!$form_state->getErrors()) {
 
       $baseUrl = $this->request->getSchemeAndHttpHost();
 
@@ -166,7 +202,6 @@ class DaxkoSSO extends GCIdentityProviderPluginBase {
       else {
         $this->messenger()->addError('Attempt to register redirect url was failed. ' . $result['message']);
       }
-      parent::submitConfigurationForm($form, $form_state);
     }
   }
 


### PR DESCRIPTION
**Related Issue/Ticket:** [#20 ](https://github.com/YCloudYUSA/yusaopeny_gated_content/issues/20)

In this PR was added a new checkbox and submit button was to update the Daxko whitelist redirect URL. Now to update this whitelist needs to do an extra effort.

## Steps to test:

- [ ] enable the Daxko Virtual YMCA integration module
- [ ] go to /admin/openy/virtual-ymca/gc-auth-settings/provider/daxkosso
- [ ] verify that you can see a new checkbox "Update Daxko URL whitelist"
- [ ] check it
- [ ] verify that you can see a new button "Confirm Update" under the checkbox
- [ ] click the button
- [ ] verify that you can see a success message "We were able to register your URL at Daxko API settings"
![Kooha-2023-03-01-19-39-33](https://user-images.githubusercontent.com/744406/222236902-4d8e0400-987f-4aac-bcd6-dc09ad8024a5.gif)


## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
