### PR TITLE
[DS-218] autologout: Don't log out if user is playing a video #17

### DIFF
--- a/modules/openy_gc_autologout/js/openy_gc_autologout.js
+++ b/modules/openy_gc_autologout/js/openy_gc_autologout.js
@@ -5,6 +5,35 @@
 (function ($, Drupal) {
 
   var awayCallback = function() {
+    var video = $('.video iframe');
+    // Check if user is on video page and logout if session expired and video is not playing.
+    if (video.length > 0) {
+      var videoUrl = video.attr('src');
+      var playerType = videoUrl.indexOf('vimeo') !== -1 ? 'vimeo' : 'youtube';
+      var player = {};
+      if (playerType === 'vimeo') {
+        player = new Vimeo.Player(video);
+        player.getPaused().then(function (paused) {
+          if (paused) {
+            awayCallbackLogout();
+          }
+        });
+      }
+      else if (playerType === 'youtube') {
+        player = YT.get(video.attr('id'));
+        // 2 video is on pause.
+        if (player.getPlayerState() === 2) {
+          awayCallbackLogout();
+        }
+      }
+    }
+    // Logout if session expired and user is on other pages.
+    else {
+      awayCallbackLogout();
+    }
+  };
+
+  var awayCallbackLogout = function() {
     $.ajax({
       url: drupalSettings.path.baseUrl + "openy_gc_autologout",
       type: "POST",

--- a/modules/openy_gc_autologout/openy_gc_autologout.libraries.yml
+++ b/modules/openy_gc_autologout/openy_gc_autologout.libraries.yml
@@ -3,6 +3,7 @@ openy_gc_autologout:
   js:
     js/idle.min.js: {}
     js/openy_gc_autologout.js: {}
+    https://player.vimeo.com/api/player.js: {}
   dependencies:
     - core/jquery
     - core/drupalSettings


### PR DESCRIPTION
[DS-218](https://yusa.atlassian.net/browse/DS-218)

## Steps to test:

- [ ] enable the Virtual Y Autologout module (with all dependencies)
- [ ] create demo content for Virtual Y
- [ ] create one video with youtube video and one with vimeo video
- [ ] go to /admin/virtual-y/openy-gc-autologout
- [ ] set timeout to 60 sec and save
- [ ] go to the Virtual Y landing page
- [ ] verify that after 60-80 sec you will be logged out from Virtual Y
- [ ] login again and go to vimeo video page
     - [ ] verify that if the video is playing you don't logged out from Virtual Y
     - [ ]  verify that if you pause the video, then you will be logged out ~60sec
- [ ] verify previous steps for the youtube video

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
