### PR TITLE
DS-68 Clean up gc_duration field before config import.

### DIFF
--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -311,6 +311,21 @@ function openy_gc_storage_update_8016() {
  * Update/create configs related to Duration reference field.
  */
 function openy_gc_storage_update_8017() {
+  // Ensure duplicate content doesn't exist before creating the field.
+  $database = \Drupal::database();
+  $tables = [
+    'taxonomy_term__field_gc_duration_max',
+    'taxonomy_term__field_gc_duration_min',
+    'taxonomy_term_revision__field_gc_duration_max',
+    'taxonomy_term_revision__field_gc_duration_min',
+  ];
+
+  foreach ($tables as $table) {
+    if ($database->schema()->tableExists($table)) {
+      $database->truncate($table);
+    }
+  }
+
   $config_dir = \Drupal::service('extension.list.module')->getPath('openy_gc_storage');
   $config_dir .= '/config/install/';
   // Update configuration.

--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -311,20 +311,24 @@ function openy_gc_storage_update_8016() {
  * Update/create configs related to Duration reference field.
  */
 function openy_gc_storage_update_8017() {
+  // If this update hook fails it's possible that content was added to the 
+  // vocabulary before it was properly created. In that case, uncomment the
+  // following commands to remove the terms before proceeding.
+  
   // Ensure duplicate content doesn't exist before creating the field.
-  $database = \Drupal::database();
-  $tables = [
-    'taxonomy_term__field_gc_duration_max',
-    'taxonomy_term__field_gc_duration_min',
-    'taxonomy_term_revision__field_gc_duration_max',
-    'taxonomy_term_revision__field_gc_duration_min',
-  ];
-
-  foreach ($tables as $table) {
-    if ($database->schema()->tableExists($table)) {
-      $database->truncate($table);
-    }
-  }
+  //  $database = \Drupal::database();
+  //  $tables = [
+  //    'taxonomy_term__field_gc_duration_max',
+  //    'taxonomy_term__field_gc_duration_min',
+  //    'taxonomy_term_revision__field_gc_duration_max',
+  //    'taxonomy_term_revision__field_gc_duration_min',
+  //  ];
+  //
+  //  foreach ($tables as $table) {
+  //    if ($database->schema()->tableExists($table)) {
+  //      $database->truncate($table);
+  //    }
+  //  }
 
   $config_dir = \Drupal::service('extension.list.module')->getPath('openy_gc_storage');
   $config_dir .= '/config/install/';


### PR DESCRIPTION
**Related Issue/Ticket:**

Fixes #7 
https://yusa.atlassian.net/browse/DS-68

## Steps to test:

This isn't really testable as it applies to an old update hook. Only way would be to roll back to an old version, reproduce the issue (that was hard to reproduce) and then run updates.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
