### PR TITLE
[DS-778] Fix the Virtual Y Content and Virtual Y Login blocks for the Layout Builder

### DIFF
--- a/assets/css/y_lb.css
+++ b/assets/css/y_lb.css
@@ -1,0 +1,13 @@
+.block-inline-blockvirtual-y-app #gated-content {
+  padding-top: 0;
+}
+
+.block-inline-blockvirtual-y-app #gated-content .top-menu {
+  position: static;
+}
+
+@media (max-width: 991px) {
+  .block-inline-blockvirtual-y-app #gated-content {
+    padding-top: 0;
+  }
+}

--- a/config/install/core.entity_view_display.block_content.virtual_y_app.default.yml
+++ b/config/install/core.entity_view_display.block_content.virtual_y_app.default.yml
@@ -13,7 +13,7 @@ mode: default
 content:
   field_virtual_y:
     type: plugin_block_built
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 0

--- a/config/install/core.entity_view_display.block_content.virtual_y_login.default.yml
+++ b/config/install/core.entity_view_display.block_content.virtual_y_login.default.yml
@@ -13,7 +13,7 @@ mode: default
 content:
   field_virtual_y_login:
     type: plugin_block_built
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 0

--- a/config/install/field.storage.block_content.field_virtual_y_login.yml
+++ b/config/install/field.storage.block_content.field_virtual_y_login.yml
@@ -1,18 +1,28 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - block_content.type.virtual_y_login
+    - field.storage.block_content.field_virtual_y_login
   module:
-    - block_content
     - plugin
-id: block_content.field_virtual_y_login
+id: block_content.virtual_y_login.field_virtual_y_login
 field_name: field_virtual_y_login
 entity_type: block_content
-type: 'plugin:block'
+bundle: virtual_y_login
+label: 'Virtual Y Login'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    plugin_id: virtual_y_login
+    plugin_configuration:
+      id: virtual_y_login
+      label: 'Virtual Y Login'
+      label_display: '0'
+      provider: openy_gc_auth
+    plugin_configuration_schema_id: block.settings.virtual_y_login
+default_value_callback: ''
 settings: {  }
-module: plugin
-locked: false
-cardinality: 1
-translatable: true
-indexes: {  }
-persist_with_no_fields: false
-custom_storage: false
+field_type: 'plugin:block'

--- a/openy_gated_content.install
+++ b/openy_gated_content.install
@@ -546,3 +546,18 @@ function openy_gated_content_update_8026() {
     'core.entity_view_display.block_content.virtual_y_login.default',
   ]);
 }
+
+/**
+ * Update "Virtual Y" & "Virtual Y Login" blocks to be used in Layout Builder.
+ */
+function openy_gated_content_update_8027() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_gated_content');
+  $config_dir .= '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'field.storage.block_content.field_virtual_y_login',
+    'core.entity_view_display.block_content.virtual_y_app.default',
+    'core.entity_view_display.block_content.virtual_y_login.default',
+  ]);
+}

--- a/openy_gated_content.libraries.yml
+++ b/openy_gated_content.libraries.yml
@@ -27,6 +27,11 @@ openy_gated_content_styles:
   css:
     theme:
       assets/css/openy_gated_content.css: {}
+y_lb:
+  version: 0.1
+  css:
+    theme:
+      assets/css/y_lb.css: {}
 
 openy-rose-menu:
   version: 0.1

--- a/openy_gated_content.module
+++ b/openy_gated_content.module
@@ -50,6 +50,10 @@ function openy_gated_content_theme() {
         'auth_form' => [],
       ],
     ],
+    'block__virtual_y_app' => [
+      'base hook' => 'block',
+      'template' => 'block--virtual-y-app',
+    ]
   ];
 }
 
@@ -156,6 +160,10 @@ function openy_gated_content_preprocess_html(&$variables) {
         }
       }
     }
+
+    if ($node->hasField('layout_builder__layout')) {
+      $variables['#attached']['library'][] = 'openy_gated_content/y_lb';
+    }
   }
 }
 
@@ -223,6 +231,29 @@ function openy_gated_content_jsonapi_taxonomy_term_filter_access(EntityTypeInter
  * Implements hook_form_alter().
  */
 function openy_gated_content_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Blocks for LB.
+  if (in_array($form_id,
+    [
+      'layout_builder_add_block',
+      'layout_builder_update_block',
+    ]
+  )) {
+    /** @var \Drupal\layout_builder\Form\ConfigureBlockFormBase $form_object */
+    $form_object = $form_state->getFormObject();
+    $component = $form_object->getCurrentComponent();
+    $plugin = $component->getPlugin();
+    $block_id = $plugin->getDerivativeId() ?? $plugin->getBaseId();
+
+    if (in_array($block_id, ['virtual_y_app', 'virtual_y_login'])) {
+      // Hide title fields that related to inline block itself.
+      $form['settings']['admin_label']['#access'] = FALSE;
+      $form['settings']['label']['#access'] = FALSE;
+      $form['settings']['label_display']['#access'] = FALSE;
+      if (isset($form['settings']['block_form'])) {
+        $form['settings']['block_form']['#process'][] = '_virtual_y_inline_block_process';
+      }
+    }
+  }
   $event_series_forms = [
     'eventseries_live_stream_edit_form',
     'eventseries_virtual_meeting_edit_form',
@@ -609,3 +640,48 @@ function openy_gated_content_entity_delete(EntityInterface $entity) {
     ->getInstanceFromDefinition(VyFavoriteItemsManager::class)
     ->deleteRelatedFavoriteItems($entity);
 }
+
+
+/**
+ * Custom process callback for inline block elements.
+ *
+ * @param array $element
+ *   Element to process.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return array
+ *   Processed element.
+ */
+function _virtual_y_inline_block_process(array $element, FormStateInterface $form_state) {
+  if (isset($element['field_virtual_y'])) {
+    $element['field_virtual_y']['widget']['#after_build'][] = '_virtual_y_select_block_field_after_build';
+  }
+  if (isset($element['field_virtual_y_login'])) {
+    $element['field_virtual_y_login']['widget']['#after_build'][] = '_virtual_y_select_block_field_after_build';
+  }
+  return $element;
+}
+
+/**
+ * Custom '#after_build' callback for field_block.
+ *
+ * @param array $element
+ *   Element to process.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return array
+ *   Processed element.
+ */
+function _virtual_y_select_block_field_after_build($element, FormStateInterface $form_state) {
+  if (isset($element[0]['plugin_selector']['container'])) {
+    // Hide the select block field.
+    $element[0]['plugin_selector']['container']['select']['container']['#attributes']['class'][] = 'hidden';
+    // Override a text before edit the Virtual Y Content block settings.
+    $element[0]['plugin_selector']['container']['plugin_form']['admin_label']['#title'] = t('Please configure your Virtual Y App block.');
+    unset($element[0]['plugin_selector']['container']['plugin_form']['admin_label']['#plain_text']);
+  }
+  return $element;
+}
+

--- a/templates/block--virtual-y-app.html.twig
+++ b/templates/block--virtual-y-app.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>


### PR DESCRIPTION
- [DS-778](https://yusa.atlassian.net/browse/DS-778)
- [DS-780](https://yusa.atlassian.net/browse/DS-780)
- [DS-781](https://yusa.atlassian.net/browse/DS-781)
- [DS-779](https://yusa.atlassian.net/browse/DS-779)


## Steps to test:

- [ ] Enable Layout Builder module.
- [ ] Enable openy_gc_auth_example module.
- [ ] Create Content Type for Layout Builder.
- [ ] Create node and add Virtual Y Content Block via Layout Builder.
- [ ] Create another node with Virtual Y Login Block via Layout Builder.
- [ ] Set up Virtual Y Landing Page url and Virtual Y Login Landing Page url fields on settings page: admin/openy/virtual-ymca
- [ ] Observe redirect to the node with Virtual Y Content Block
- [ ] Navigate to the page with Virtual Y Content Login block and hit Enter Virtual Y button.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
