### PR TITLE
[DS-794] Fix styles of the Virtual Y content page for LB for the Carnation theme

### DIFF
--- a/assets/css/y_lb.css
+++ b/assets/css/y_lb.css
@@ -2,12 +2,29 @@
   padding-top: 0;
 }
 
-.block-inline-blockvirtual-y-app #gated-content .top-menu {
-  position: static;
+.openy_carnation-based.openy-gated-content #gated-content .top-menu {
+  top: 0 !important;
+  left: 0;
+  padding: 0 15px;
+}
+
+.openy_carnation.openy-gated-content article,
+.openy_carnation.openy-gated-content .openy-page-tabs {
+  display: block;
+}
+
+.openy_carnation.openy-gated-content article .ws-header {
+  padding-top: 87px;
 }
 
 @media (max-width: 991px) {
   .block-inline-blockvirtual-y-app #gated-content {
     padding-top: 0;
+  }
+  .openy_carnation.openy-gated-content article .ws-header {
+    padding-top: 49px;
+  }
+  .openy_carnation-based.openy-gated-content #gated-content .top-menu {
+    padding: 0 15px;
   }
 }

--- a/openy_gated_content.libraries.yml
+++ b/openy_gated_content.libraries.yml
@@ -28,7 +28,7 @@ openy_gated_content_styles:
     theme:
       assets/css/openy_gated_content.css: {}
 y_lb:
-  version: 0.1
+  version: 0.2
   css:
     theme:
       assets/css/y_lb.css: {}

--- a/openy_gated_content.module
+++ b/openy_gated_content.module
@@ -163,6 +163,8 @@ function openy_gated_content_preprocess_html(&$variables) {
 
     if ($node->hasField('layout_builder__layout')) {
       $variables['#attached']['library'][] = 'openy_gated_content/y_lb';
+      $variables['attributes']['class'][] = openy_gated_content_get_base_theme() . '-based';
+      $variables['attributes']['class'][] = 'openy-gated-content';
     }
   }
 }


### PR DESCRIPTION
[DS-794](https://yusa.atlassian.net/browse/DS-794)

## Steps to test:

- [ ] Set Carnation as default theme 
- [ ] Enable Layout Builder module.
- [ ]  Enable openy_gc_auth_example module.
- [ ]  Create Content Type for Layout Builder.
- [ ]  Create node and add Virtual Y Content Block via Layout Builder.
- [ ]  Create another node with Virtual Y Login Block via Layout Builder.
- [ ]  Set up Virtual Y Landing Page url and Virtual Y Login Landing Page url fields on settings page: admin/openy/virtual-ymca
- [ ]  Go to  Virtual Y Content Block page
- [ ]  Verify that Virtual Y menu s sticky and looks good for all type of screen

Desktop:
![DS-794-desktop](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/dd1b5d75-ae3d-40ca-ba79-73f9c0b6b052)

Tablet:
![DS-794-tablet](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/5a22bbd8-a145-4c1f-9703-8a0792d19a4e)


Mobile:
![DS-794-mobile](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/8dfba089-f62e-4cae-aad2-8424a99d681c)



## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
