### PR TITLE
[DS-795] Fix redirect after login for Virtual Y App in LB

### DIFF
--- a/modules/openy_gc_auth/src/GCAuthManager.php
+++ b/modules/openy_gc_auth/src/GCAuthManager.php
@@ -74,7 +74,7 @@ class GCAuthManager {
       $section = $section['section'];
 
       foreach ($section->getComponents() as $component) {
-        if ($component->getPluginId() === $block_id) {
+        if (strpos($component->getPluginId(), $block_id) !== false) {
           return TRUE;
         }
       }


### PR DESCRIPTION
[DS-795](https://yusa.atlassian.net/browse/DS-795)

## Steps to test:

- [ ]  Enable Layout Builder module.
- [ ]  Enable openy_gc_auth_example module.
- [ ]  Create Content Type for Layout Builder.
- [ ]  Create node and add Virtual Y Content Block via Layout Builder.
- [ ]  Create another node with Virtual Y Login Block via Layout Builder.
- [ ]  Set up Virtual Y Landing Page url and Virtual Y Login Landing Page url fields on settings page: admin/openy/virtual-ymca
- [ ]  Observe redirect to the node with Virtual Y Content Block
- [ ]  Navigate to the page with Virtual Y Content Login block and hit Enter Virtual Y button.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
