### PR TITLE
fix: Add update dependencies for ckeditor5 and recurring_events

### DIFF
--- a/openy_gated_content.install
+++ b/openy_gated_content.install
@@ -40,6 +40,15 @@ function openy_gated_content_update_dependencies() {
     8022 => [
       'openy_txnm_color' => 8005,
     ],
+    8026 => [
+      'openy' => 8093,
+    ]
+  ];
+
+  $dependencies['openy'] = [
+    8093 => [
+      'recurring_events' => 8012,
+    ]
   ];
 
   return $dependencies;


### PR DESCRIPTION
Resolves update issues like:

>  [error]  Configuration <em class="placeholder">editor.editor.full_html</em> depends on the <em class="placeholder">CKEditor 5</em> module that will not be installed after import. 

and

>  [error]  Column information not available for the 'event_instances' field. 

Also ensure https://www.drupal.org/project/recurring_events/issues/3376639 is committed or added via patch if not.

**Related Issue/Ticket:** 

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

https://yusa.atlassian.net/browse/DS-902
see also https://github.com/YCloudYUSA/yusaopeny/pull/94

## Steps to test:

- [ ] Update from VY 9.5 or an older version
- [ ] Run `updb`
- [ ] Observe ` [success] Finished performing updates.`

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
