### PR TITLE
[DS-875] Add a small fix for the Virtual Y header after QA phase

### DIFF
--- a/assets/css/y_lb.css
+++ b/assets/css/y_lb.css
@@ -2,11 +2,11 @@
   padding-top: 0;
 }
 
-.openy_carnation-based.virtual-ymca #gated-content {
+.openy_carnation-based.page-with-lb #gated-content {
   padding-top: 0;
 }
 
-.openy_carnation-based.virtual-ymca #gated-content .top-menu {
+.openy_carnation-based.page-with-lb #gated-content .top-menu {
   top: 142px;
   padding: 0 15px;
   left: 0;
@@ -19,7 +19,7 @@
   display: block;
 }
 
-.openy_carnation.virtual-ymca article .ws-header {
+.openy_carnation.page-with-lb article .ws-header {
   position: fixed;
   top: 0;
   left: 0;
@@ -28,19 +28,19 @@
   z-index: 101;
 }
 
-.openy_carnation-based.virtual-ymca #openy_alerts_app_header {
+.openy_carnation-based.page-with-lb #openy_alerts_app_header {
   margin-top: 216px;
 }
 
-.openy_carnation-based.virtual-ymca #gated-content .gated-content-schedule-page {
+.openy_carnation-based.page-with-lb #gated-content .gated-content-schedule-page {
   padding-top: 0 !important;
 }
 
-.openy_carnation-based.virtual-ymca #gated-content .gated-content-schedule-page .date-filter {
+.openy_carnation-based.page-with-lb #gated-content .gated-content-schedule-page .date-filter {
   position: sticky;
   top: 200px;
 }
-.openy_carnation-based.virtual-ymca #gated-content .gated-content-schedule-page .calendar .slot.dates {
+.openy_carnation-based.page-with-lb #gated-content .gated-content-schedule-page .calendar .slot.dates {
   position: static;
 }
 

--- a/openy_gated_content.libraries.yml
+++ b/openy_gated_content.libraries.yml
@@ -29,7 +29,7 @@ openy_gated_content_styles:
       assets/css/openy_gated_content.css: {}
 
 y_lb:
-  version: 0.3
+  version: 0.4
   js:
     assets/js/y_lb.behaviors.js: { minified: false }
   css:


### PR DESCRIPTION
[DS-875](https://yusa.atlassian.net/browse/DS-875?focusedCommentId=12804)

## Steps to test:

- [ ] log as admin
- [ ] create a new page with LB
- [ ] add the Virtual Y Content block to the body section and save the layout
- [ ] verify that the Virtual Y header is sticky while scrolling the page
![image](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/0b64efec-994f-409c-a44c-2f353882bdab)



## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
