### PR TITLE
[DS-1157] Add accessCheck for DB queries

### DIFF
--- a/modules/openy_gc_log/openy_gc_log.module
+++ b/modules/openy_gc_log/openy_gc_log.module
@@ -75,7 +75,7 @@ function openy_gc_log_file_download($uri) {
   }
 
   return [
-    'Content-Type' => \Drupal::service('file.mime_type.guesser')->guess($uri),
+    'Content-Type' => \Drupal::service('file.mime_type.guesser')->guessMimeType($uri),
     'Content-Disposition' => 'inline',
   ];
 }

--- a/modules/openy_gc_log/openy_gc_log.post_update.php
+++ b/modules/openy_gc_log/openy_gc_log.post_update.php
@@ -14,6 +14,7 @@ function openy_gc_log_post_update_update_metadata(&$sandbox) {
   $storage = Drupal::entityTypeManager()->getStorage('log_entity');
   if (!isset($sandbox['max'])) {
     $query = $storage->getQuery()
+      ->accessCheck()
       ->condition('event_type', [
         LogEntityInterface::EVENT_TYPE_ENTITY_VIEW,
         LogEntityInterface::EVENT_TYPE_VIDEO_PLAYBACK_STARTED,

--- a/modules/openy_gc_log/openy_gc_log.post_update.php
+++ b/modules/openy_gc_log/openy_gc_log.post_update.php
@@ -14,7 +14,7 @@ function openy_gc_log_post_update_update_metadata(&$sandbox) {
   $storage = Drupal::entityTypeManager()->getStorage('log_entity');
   if (!isset($sandbox['max'])) {
     $query = $storage->getQuery()
-      ->accessCheck()
+      ->accessCheck(TRUE)
       ->condition('event_type', [
         LogEntityInterface::EVENT_TYPE_ENTITY_VIEW,
         LogEntityInterface::EVENT_TYPE_VIDEO_PLAYBACK_STARTED,

--- a/modules/openy_gc_log/src/LogArchiver.php
+++ b/modules/openy_gc_log/src/LogArchiver.php
@@ -263,7 +263,7 @@ class LogArchiver {
     $query = $this->entityTypeManager
       ->getStorage('log_entity')
       ->getQuery()
-      ->accessCheck()
+      ->accessCheck(TRUE)
       ->condition('created', [$start_time, $end_time], 'BETWEEN')
       ->sort('created', 'ASC');
 
@@ -288,7 +288,7 @@ class LogArchiver {
   protected function loadActivityLogIdsByDateRange($start_time, $end_time) {
     $query = $this->entityTypeManager->getStorage('log_entity')
       ->getQuery()
-      ->accessCheck()
+      ->accessCheck(TRUE)
       ->condition('event_type', LogEntityInterface::EVENT_TYPE_USER_ACTIVITY)
       ->condition('created', [$start_time, $end_time], 'BETWEEN')
       ->sort('created', 'ASC');
@@ -548,7 +548,7 @@ class LogArchiver {
     $file_ids = $this->entityTypeManager
       ->getStorage('file')
       ->getQuery()
-      ->accessCheck()
+      ->accessCheck(TRUE)
       ->condition('filename', array_keys($this->preparedLogs), 'in')
       ->execute();
 

--- a/modules/openy_gc_log/src/Logger.php
+++ b/modules/openy_gc_log/src/Logger.php
@@ -95,7 +95,7 @@ class Logger {
     try {
       $interval = $this->configFactory->get('openy_gc_log.settings')->get('activity_granularity_interval');
       $query = $this->entityTypeManager->getStorage('log_entity')->getQuery();
-      $query->accessCheck();
+      $query->accessCheck(TRUE);
       $query->condition('uid', $user_id);
       $query->condition('event_type', LogEntityInterface::EVENT_TYPE_USER_ACTIVITY);
       $query->condition('changed', (new \DateTime("-$interval seconds"))->getTimestamp(), '>=');

--- a/modules/openy_gc_log/src/Logger.php
+++ b/modules/openy_gc_log/src/Logger.php
@@ -95,6 +95,7 @@ class Logger {
     try {
       $interval = $this->configFactory->get('openy_gc_log.settings')->get('activity_granularity_interval');
       $query = $this->entityTypeManager->getStorage('log_entity')->getQuery();
+      $query->accessCheck();
       $query->condition('uid', $user_id);
       $query->condition('event_type', LogEntityInterface::EVENT_TYPE_USER_ACTIVITY);
       $query->condition('changed', (new \DateTime("-$interval seconds"))->getTimestamp(), '>=');


### PR DESCRIPTION
[DS-903](https://yusa.atlassian.net/browse/DS-903)
Should fix these errors:
![GClogError](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/eef36fef-26ba-4fa1-8b00-ef838411225b)

## Steps to test:

- [ ] Update to D10 and the latest VY
- [ ] Enable VY Logs module
- [ ] Hit the front-end a couple times to generate log entries
- [ ] go to /admin/reports/dblog
- [ ] verify that you don't see the 'Entity queries must explicitly set whether the query should be access checked or not. See Drupal\Core\Entity\Query\QueryInterface::accessCheck().' errors

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
