### PR TITLE
Revert main nav font size change

### DIFF
--- a/assets/css/openy_carnation.css
+++ b/assets/css/openy_carnation.css
@@ -11,7 +11,6 @@
 }
 @media (min-width: 1060px) {
   .openy_carnation .desktop-menu .page-head__main-menu .navbar > li > a {
-    font-size: 14px;
     line-height: 21px;
     padding-left: 2px;
     padding-right: 2px;

--- a/openy_gated_content.libraries.yml
+++ b/openy_gated_content.libraries.yml
@@ -11,7 +11,7 @@ openy_lily_styles:
       assets/css/openy_lily.css: {}
 
 openy_carnation_styles:
-  version: 0.2
+  version: 0.3
   css:
     theme:
       assets/css/openy_carnation.css: {}


### PR DESCRIPTION
**Related Issue/Ticket:**

Community request

## Steps to test:

- [ ] Observe VY main nav font size matches the rest of the site

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
