### PR TITLE
[DS-1076] Fix heading position for pages without alerts banner

### DIFF
--- a/assets/css/y_lb.css
+++ b/assets/css/y_lb.css
@@ -28,7 +28,8 @@
   z-index: 101;
 }
 
-.openy_carnation-based.page-with-lb #openy_alerts_app_header {
+.openy_carnation-based.page-with-lb.alerts #openy_alerts_app_header,
+.openy_carnation-based.page-with-lb:not(.alerts) #gated-content {
   margin-top: 216px;
 }
 
@@ -47,5 +48,8 @@
 @media (max-width: 991px) {
   #openy_alerts_app_header {
     margin-top: 189px;
+  }
+  .openy_carnation-based.page-with-lb:not(.alerts) #gated-content {
+    margin-top: 0;
   }
 }

--- a/openy_gated_content.libraries.yml
+++ b/openy_gated_content.libraries.yml
@@ -29,7 +29,7 @@ openy_gated_content_styles:
       assets/css/openy_gated_content.css: {}
 
 y_lb:
-  version: 0.4
+  version: 0.5
   js:
     assets/js/y_lb.behaviors.js: { minified: false }
   css:


### PR DESCRIPTION
[DS-1076](https://yusa.atlassian.net/browse/DS-1076)
![VirtualYHeader](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/db907f84-5f41-42a9-9528-5c9b25317467)


## Steps to test:

- [ ] log in as admin https://sandbox-carnation-std-virtual-y.y.org/
- [ ] create a Landing page Layout Builder
- [ ] Add Virtual Y Content block in LB and save the page
- [ ] as an anonymous user log in to the site and open created page

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
