### PR TITLE
[DS-1204] Set default value for creator_plugin options of the eventseries config

### DIFF
--- a/modules/openy_gc_storage/config/install/recurring_events.eventseries.config.yml
+++ b/modules/openy_gc_storage/config/install/recurring_events.eventseries.config.yml
@@ -12,3 +12,4 @@ threshold_warning: 1
 threshold_count: 200
 threshold_message: 'Saving this series will create up to @total event instances. This could result in memory exhaustion or site instability. Please try again with a smaller date range.'
 threshold_prevent_save: 0
+creator_plugin: 'recurring_events_eventinstance_recreator'

--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -372,3 +372,10 @@ function openy_gc_storage_update_8018() {
     'field_inheritance.field_inheritance.eventinstance_virtual_meeting_instructor_reference',
   ]);
 }
+
+/**
+ * Add default value for creator_plugin option in Recurring Events Series config.
+ */
+function openy_gc_storage_update_9101() {
+  openy_gc_storage_update_8005();
+}


### PR DESCRIPTION
[DS-1204](https://yusa.atlassian.net/browse/DS-1204)

## Steps to test:
- [ ] log. in as a CMS user
- [ ] install VY Log and Field UI modules
- [ ] go to. /admin/structure/events/series/types/eventseries_type/live_stream/edit/form-display and enable Hosts name field
- [ ] go to the event series
- [ ] edit any event series > add instructor in Hosts name field and click on the Save button

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
