### PR TITLE
[DS-805] Fix the end time of the demo events to display the correct duration information in the schedule.

### DIFF
--- a/modules/openy_gc_demo/migrations/migrate_plus.migration.virtual_y_reccuring_event_live_stream.yml
+++ b/modules/openy_gc_demo/migrations/migrate_plus.migration.virtual_y_reccuring_event_live_stream.yml
@@ -28,6 +28,7 @@ source:
       equipment: 8
       level: 4
       time: '8:00 am'
+      end_event_time: '8:15 am'
       duration: 900
     -
       id: 2
@@ -45,6 +46,7 @@ source:
       equipment: 8
       level: 2
       time: '11:00 am'
+      end_event_time: '11:45 am'
       duration: 2700
   ids:
     id:
@@ -123,6 +125,10 @@ process:
       plugin: date_timestamp
       to_format: 'Y-m-d\TH:i:s'
   'daily_recurring_date/time': time
+  'daily_recurring_date/end_time': end_event_time
+  'daily_recurring_date/duration_or_end_time':
+    - plugin: default_value
+      default_value: 'end_time'
   'daily_recurring_date/duration': duration
 destination:
   plugin: 'entity:eventseries'

--- a/modules/openy_gc_demo/migrations/migrate_plus.migration.virtual_y_reccuring_event_virtual_meeting.yml
+++ b/modules/openy_gc_demo/migrations/migrate_plus.migration.virtual_y_reccuring_event_virtual_meeting.yml
@@ -25,6 +25,7 @@ source:
       equipment: 7
       level: 4
       time: '9:00 am'
+      end_event_time: '9:15 am'
       duration: 900
       link: 'http://example.com/'
     -
@@ -41,6 +42,7 @@ source:
       equipment: 7
       level: 3
       time: '10:00 am'
+      end_event_time: '10:45 am'
       duration: 2700
       link: 'http://example.com/'
   ids:
@@ -116,6 +118,10 @@ process:
       plugin: date_timestamp
       to_format: 'Y-m-d\TH:i:s'
   'daily_recurring_date/time': time
+  'daily_recurring_date/end_time': end_event_time
+  'daily_recurring_date/duration_or_end_time':
+    - plugin: default_value
+      default_value: 'end_time'
   'daily_recurring_date/duration': duration
 destination:
   plugin: 'entity:eventseries'


### PR DESCRIPTION
**Related Issue/Ticket:**
[DS-805](https://yusa.atlassian.net/browse/DS-805)


## Steps to test:

- [ ] Run migration with Virtual Y Demo content
- [ ] Go to /virtual-ymca?check_logged_in=1#/schedule
- [ ] Verify that events in the table have the correct duration information.
![image](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/5df74f51-fa8a-48a8-90d2-c1b8b666dd35)


## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
