### PR TITLE
[Ds-1300] Fix deprecation code (once and cookie) in js files

### DIFF
--- a/modules/openy_gc_auth/js/auth.behaviors.js
+++ b/modules/openy_gc_auth/js/auth.behaviors.js
@@ -1,4 +1,4 @@
-(function ($, Drupal) {
+(function ($, Drupal, cookies) {
  Drupal.behaviors.openy_gc_auth_store_hash = {
    attach: function (context) {
      // Only run this script on full documents, not ajax requests.
@@ -8,7 +8,7 @@
      if (!window.location.hash || window.location.hash === '#') {
        return;
      }
-     $.cookie('openy_gc_auth_destination', window.location.hash);
+     cookies.set('openy_gc_auth_destination', window.location.hash);
    }
  }
-})(jQuery, Drupal);
+})(jQuery, Drupal, window.Cookies);

--- a/modules/openy_gc_auth/modules/openy_gc_auth_example/js/openy_gc_auth_example.js
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_example/js/openy_gc_auth_example.js
@@ -2,12 +2,13 @@
  * @file
  * JavaScript for openy_gc_auth_example.
  */
-(function ($, Drupal) {
+(function ($, Drupal, once) {
 
   Drupal.behaviors.openy_gc_auth_example = {
     attach: function(context, settings) {
-      $('input[data-autosubmit=1]', context).once('openy_gc_auth_example').form().submit();
+      $(once('openy_gc_auth-data-autosubmit', 'input[data-autosubmit=1]'))
+        .form().submit();
     }
   };
 
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);

--- a/modules/openy_gc_auth/modules/openy_gc_auth_example/openy_gc_auth_example.libraries.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_example/openy_gc_auth_example.libraries.yml
@@ -1,6 +1,7 @@
 openy_gc_auth_example:
-  version: 1.0
+  version: 1.1
   js:
     js/openy_gc_auth_example.js: { minified: false }
   dependencies:
     - core/jquery
+    - core/once

--- a/modules/openy_gc_auth/openy_gc_auth.libraries.yml
+++ b/modules/openy_gc_auth/openy_gc_auth.libraries.yml
@@ -1,7 +1,7 @@
 auth_destination:
-  version: 0.1
+  version: 0.2
   js:
     js/auth.behaviors.js: {}
   dependencies:
     - core/jquery
-    - core/jquery.cookie
+    - core/js-cookie


### PR DESCRIPTION
**Related Issue/Ticket:**
[DS-1300](https://yusa.atlassian.net/browse/DS-1300)

## Steps to test:

- [ ] Go to the site with virtual Y that uses as the default theme Rose or Lilly
- [ ] Open Dev Tools
- [ ] Verify that you don't see js-errors in the console
![image](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/15fb127f-060e-4253-80b3-bf085c65bac9)

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
