### PR TITLE
[DS-1300] Add a fix for the auto-submit auth form functionality of the openy_gc_auth_example module

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_example/js/openy_gc_auth_example.js
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_example/js/openy_gc_auth_example.js
@@ -6,8 +6,10 @@
 
   Drupal.behaviors.openy_gc_auth_example = {
     attach: function(context, settings) {
-      $(once('openy_gc_auth-data-autosubmit', 'input[data-autosubmit=1]'))
-        .form().submit();
+      if ($('.openy-gc-auth-example-login-form').find('.form-submit').attr('data-autosubmit') === '1') {
+        $(once('openy_gc_auth_example_form_autosubmit', '.openy-gc-auth-example-login-form', context))
+          .trigger( "submit" );
+      }
     }
   };
 


### PR DESCRIPTION
**Related Issue/Ticket:**
[DS-1300](https://yusa.atlassian.net/browse/DS-1300)

## Steps to test:

- [ ] go to /virtual-y-login page
- [ ] Open the DevTools
- [ ] verify that you don't see the any error messages in the console
- [ ] log in as admin
- [ ] go to /admin/openy/virtual-ymca/gc-auth-settings/provider/dummy
- [ ] Turn on the **Autosubmit** flag and save the form
- [ ] go  to /virtual-y-login page as anonym
- [ ] verify that you automatically logged in to Virtual Y account

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
