### PR TITLE
[DS-889] Upgrade axios library up to version 1.4

### DIFF
--- a/js/gated-content/package.json
+++ b/js/gated-content/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@vue/babel-preset-app": "^3.12.1",
-    "axios": "^0.21.1",
+    "axios": "1.4.0",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^4.5.3",
     "calendar-link": "^1.3.1",

--- a/openy_gated_content.libraries.yml
+++ b/openy_gated_content.libraries.yml
@@ -51,13 +51,18 @@ alerts:
   js:
     assets/js/alerts.behaviors.js: { minified: false }
 
+axios:
+  version: 1.4.0
+  js:
+    https://cdnjs.cloudflare.com/ajax/libs/axios/1.4.0/axios.min.js: { type: external, minified: true }
+
 gated-content-vue:
   version: 0.3
   js:
     js/gated-content/dist/gated-content.umd.min.js: { minified: true }
   dependencies:
     - openy_system/polyfill
-    - openy_system/axios
+    - openy_gated_content/axios
     - openy_system/vue
     - openy_system/vue-router
     - openy_system/vuex


### PR DESCRIPTION
**Related Issue/Ticket:**

[DS-889](https://yusa.atlassian.net/browse/DS-889)

## Steps to test:

- [ ] Log in to Virtual Y account
- [ ] Verify that you can see the Virtual Y content
- [ ] Open the DevTools on the Network tab
- [ ] Filter by 'axios' keyword
- [ ] Verify that you see the version of the axios library and if it has 1.4.0 version

![image](https://github.com/YCloudYUSA/yusaopeny_gated_content/assets/744406/cdf9ff68-b7f5-4062-a443-14ac5a57b10d)


## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
