### PR TITLE
fix: 500(white page) error when daxko return error response

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Controller/DaxkoBarcodeController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Controller/DaxkoBarcodeController.php
@@ -197,7 +197,7 @@ class DaxkoBarcodeController extends ControllerBase {
       watchdog_exception('openy_gc_auth_daxko_barcode', $e);
     }
 
-    $response_status = $request->getStatusCode();
+    $response_status = $request?->getStatusCode();
     if ($response_status == 302) {
       $location = $request->getHeader('Location');
       return UrlHelper::parse(array_shift($location))['query'];


### PR DESCRIPTION
Just add null-safe operator to avoid $request is undefined error after try/catch block.