### PR TITLE
Fix broken gated content styles on non-LB pages

### DIFF
--- a/openy_gated_content.module
+++ b/openy_gated_content.module
@@ -83,11 +83,16 @@ function openy_gated_content_preprocess_paragraph(&$variables) {
     return;
   }
 
-  // Target only gated content paragraph.
-  if ($variables['paragraph']->getType() != 'gated_content') {
+  $paragraph = $variables['paragraph'];
+  $type = $paragraph->bundle();
+
+  if (!in_array($type, ['gated_content', 'gated_content_login'])) {
     return;
   }
 
+  // Attach needed libraries.
+  $variables['#attached']['library'][] = 'openy_gated_content/openy_carnation_styles';
+  $variables['#attached']['library'][] = 'openy_gated_content/y_lb';
   $variables['#cache']['tags'][] = 'config:openy_gated_content.settings';
   $variables['#cache']['tags'][] = 'config:openy_gc_auth.settings';
 


### PR DESCRIPTION
**Problem:**
The gated content styles are broken on regular pages that do not use Layout Builder.

**Cause:**
The required libraries (`openy_gated_content/openy_carnation_styles` and `openy_gated_content/y_lb`) were attached only via `hook_preprocess_block()` to `virtual_y_app` and `virtual_y_login` inline blocks. ([PR](https://github.com/YCloudYUSA/yusaopeny_gated_content/pull/101)) These blocks are only used when Layout Builder is enabled.

When the same paragraphs (`gated_content`, `gated_content_login`) are placed as part of a node (e.g., Landing Page) without Layout Builder, those libraries are not attached, resulting in missing styles and incorrect layout.

**Fix:**
Attach the necessary libraries in `hook_preprocess_paragraph()` for both` gated_content` and `gated_content_login` paragraph types so that styles are consistently applied across all contexts.
**Related Issue/Ticket:**

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

(Replace this line with a link to the related GitHub issue on [YCloudYUSA/yusaopeny_gated_content](https://github.com/YCloudYUSA/yusaopeny_gated_content/issues) or your own ticketing system)

## Steps to test:

- [ ] First do this
- [ ] Then do this (and look at this great screenshot).
- [ ] Finally observe the issue is resolved.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
