### PR TITLE
fix: Add hook to fix media view browser_thumbnail image style

### DIFF
--- a/modules/openy_gc_storage/openy_gc_storage.post_update.php
+++ b/modules/openy_gc_storage/openy_gc_storage.post_update.php
@@ -396,3 +396,30 @@ function openy_gc_storage_post_update_migrate_live_stream_media_field() {
 
   return t('field_ls_media already using media_library widget, no migration needed.');
 }
+
+/**
+ * Fix media view thumbnail image style from browser_thumbnail to media_library.
+ *
+ * The browser_thumbnail image style was removed with entity_browser deprecation,
+ * causing "Call to a member function getCacheTags() on null" error on
+ * /admin/content/media page.
+ */
+function openy_gc_storage_post_update_fix_media_view_image_style() {
+  $config = \Drupal::configFactory()->getEditable('views.view.media');
+
+  if ($config->isNew()) {
+    return t('Media view not found, skipping.');
+  }
+
+  $image_style = $config->get('display.default.display_options.fields.thumbnail__target_id.settings.image_style');
+
+  if ($image_style === 'browser_thumbnail') {
+    $config->set('display.default.display_options.fields.thumbnail__target_id.settings.image_style', 'media_library');
+    $config->save();
+    return t('Changed media view thumbnail image_style from browser_thumbnail to media_library.');
+  }
+
+  return t('Media view image_style is already correct (@style), no change needed.', [
+    '@style' => $image_style,
+  ]);
+}


### PR DESCRIPTION
# Bug Fix: Fix media view image style after entity_browser removal

**Type**: Bug Fix
**Priority**: High

---

## 📋 Summary

### What does this PR do?

Adds a post_update hook to fix the media view thumbnail image style from `browser_thumbnail` to `media_library`.

### Why is this change needed?

After entity_browser deprecation, the `browser_thumbnail` image style no longer exists. This causes **"Call to a member function getCacheTags() on null"** error on `/admin/content/media` page.

---

## 🔄 Changes Made

**File**: `modules/openy_gc_storage/openy_gc_storage.post_update.php`
- Added `openy_gc_storage_post_update_fix_media_view_image_style()` hook
- Changes `views.view.media` thumbnail field image_style from `browser_thumbnail` to `media_library`

---

## 🧪 Testing

1. Have a site with Virtual Y that shows error on `/admin/content/media`
2. Run `drush updb -y`
3. Verify `/admin/content/media` works without error

---

## 🔗 Related

- Follow-up to PR #112 (2.0.1 release)
- Related to entity_browser deprecation fixes