### PR TITLE
feature/118-fix-issue-with-php-8-4-deprecations|Fixed the issue with …

### DIFF
--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -142,8 +142,8 @@ class EventsController extends ControllerBase {
    */
   protected function getEventInstances(
     array $bundles,
-    DrupalDateTime $start_date = NULL,
-    DrupalDateTime $end_date = NULL
+    ?DrupalDateTime $start_date = NULL,
+    ?DrupalDateTime $end_date = NULL
   ): array {
     $roles = $this->currentUser()->getRoles(TRUE);
     $vy_roles = array_filter($roles, function ($role) {


### PR DESCRIPTION
Deprecated: Drupal\openy_gated_content\Controller\EventsController::getEventInstances(): Implicitly marking parameter $start_date as nullable is deprecated, the explicit nullable type must be used instead in ..docroot/modules/contrib/yusaopeny_gated_content/src/Controller/EventsController.php on line 143


